### PR TITLE
WIP: Add support for retrying on Elasticsearch errors, and dynamic index prefix support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,10 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in fluent-plugin-elasticsearch.gemspec
+gem 'fluentd', '~> 0.12.0'
+
 gemspec
+
 
 gem 'simplecov', require: false
 gem 'coveralls', require: false

--- a/Gemfile.v0.14
+++ b/Gemfile.v0.14
@@ -1,10 +1,7 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in fluent-plugin-elasticsearch.gemspec
-gem 'fluentd', '~> 0.12.0'
-
 gemspec
-
 
 gem 'simplecov', require: false
 gem 'coveralls', require: false

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Note: For Amazon Elasticsearch Service please consider using [fluent-plugin-aws-
   + [user, password, path, scheme, ssl_verify](#user-password-path-scheme-ssl_verify)
   + [logstash_format](#logstash_format)
   + [logstash_prefix](#logstash_prefix)
+  + [logstash_prefix_key](#logstash_prefix_key)
   + [logstash_dateformat](#logstash_dateformat)
   + [time_key_format](#time_key_format)
   + [time_precision](#time_precision)
@@ -113,13 +114,48 @@ Specify `ssl_verify false` to skip ssl verification (defaults to true)
 logstash_format true # defaults to false
 ```
 
-This is meant to make writing data into ElasticSearch indices compatible to what [Logstash](https://www.elastic.co/products/logstash) calls them. By doing this, one could take advantage of [Kibana](https://www.elastic.co/products/kibana). See logstash_prefix and logstash_dateformat to customize this index name pattern. The index name will be `#{logstash_prefix}-#{formated_date}`
+This is meant to make writing data into Elastisearch indices compatible to what [Logstash](https://www.elastic.co/products/logstash) calls them. By doing this, one could take advantage of [Kibana](https://www.elastic.co/products/kibana). See logstash_prefix, logstash_prefix_key, and logstash_dateformat to customize this index name pattern. The index name will be `#{logstash_prefix}-#{formated_date}`.
 
 ### logstash_prefix
+
+The index name prefix to use when forming the full index name.  The index name will be `#{logstash_prefix}-#{formated_date}`.  See also logstash_prefix_key and logstash_dateformat for other customizations.
 
 ```
 logstash_prefix mylogs # defaults to "logstash"
 ```
+
+### logstash_prefix_key
+
+Tell this plugin to find the index name prefix used to contruct the index name to write to in the record under this key. Key can be specified as path to nested record using dot ('.') as a separator.
+
+If it is present in the record (and the value is non falsey) the value will be used as the index name prefix, and then removed from the record before output; if it is not found, then the logstash_prefix default value will be used.
+
+Suppose you have the following settings
+
+```
+logstash_prefix_key @index_prefix
+logstash_prefix fallback
+```
+
+If your input is:
+```
+{
+  "title": "developer",
+  "@timestamp": "2014-12-19T08:01:03Z",
+  "@index_prefix": "dev"
+}
+```
+
+The output would be
+
+```
+{
+  "title": "developer",
+  "@timestamp": "2014-12-19T08:01:03Z",
+}
+```
+
+and this record will be written to the index, `dev-2014.12.19`, rather than `fallback-2014.12.19`.
 
 ### logstash_dateformat
 
@@ -264,7 +300,7 @@ If `template_file` and `template_name` are set, then this parameter will be igno
 
 You can specify HTTP request timeout.
 
-This is useful when ElasticSearch cannot return response for bulk request within the default of 5 seconds.
+This is useful when Elasticsearch cannot return response for bulk request within the default of 5 seconds.
 
 ```
 request_timeout 15s # defaults to 5s
@@ -272,7 +308,7 @@ request_timeout 15s # defaults to 5s
 
 ### reload_connections
 
-You can tune how the elasticsearch-transport host reloading feature works. By default it will reload the host list from the server every 10,000th request to spread the load. This can be an issue if your ElasticSearch cluster is behind a Reverse Proxy, as Fluentd process may not have direct network access to the ElasticSearch nodes.
+You can tune how the elasticsearch-transport host reloading feature works. By default it will reload the host list from the server every 10,000th request to spread the load. This can be an issue if your Elasticsearch cluster is behind a Reverse Proxy, as Fluentd process may not have direct network access to the Elasticsearch nodes.
 
 ```
 reload_connections false # defaults to true
@@ -312,7 +348,7 @@ This will add the Fluentd tag in the JSON record. For instance, if you have a co
 </match>
 ```
 
-The record inserted into ElasticSearch would be
+The record inserted into Elasticsearch would be
 
 ```
 {"_key":"my.logs", "name":"Johnny Doeie"}
@@ -324,9 +360,9 @@ The record inserted into ElasticSearch would be
 id_key request_id # use "request_id" field as a record id in ES
 ```
 
-By default, all records inserted into ElasticSearch get a random _id. This option allows to use a field in the record as an identifier.
+By default, all records inserted into Elasticsearch get a random _id. This option allows to use a field in the record as an identifier.
 
-This following record `{"name":"Johnny","request_id":"87d89af7daffad6"}` will trigger the following ElasticSearch command
+This following record `{"name":"Johnny","request_id":"87d89af7daffad6"}` will trigger the following Elasticsearch command
 
 ```
 { "index" : { "_index" : "logstash-2013.01.01, "_type" : "fluentd", "_id" : "87d89af7daffad6" } }
@@ -344,7 +380,7 @@ If your input is
 { "name": "Johnny", "a_parent": "my_parent" }
 ```
 
-ElasticSearch command would be
+Elasticsearch command would be
 
 ```
 { "index" : { "_index" : "****", "_type" : "****", "_id" : "****", "_parent" : "my_parent" } }
@@ -418,12 +454,12 @@ reconnect_on_error true # defaults to false
 
 ### Client/host certificate options
 
-Need to verify ElasticSearch's certificate?  You can use the following parameter to specify a CA instead of using an environment variable.
+Need to verify Elasticsearch's certificate?  You can use the following parameter to specify a CA instead of using an environment variable.
 ```
 ca_file /path/to/your/ca/cert
 ```
 
-Does your ElasticSearch cluster want to verify client connections?  You can specify the following parameters to use your client certificate, key, and key password for your connection.
+Does your Elasticsearch cluster want to verify client connections?  You can specify the following parameters to use your client certificate, key, and key password for your connection.
 ```
 client_cert /path/to/your/client/cert
 client_key /path/to/your/private/key
@@ -471,7 +507,7 @@ Note that the flattener does not deal with arrays at this time.
 
 We try to keep the scope of this plugin small and not add too many configuration options. If you think an option would be useful to others, feel free to open an issue or contribute a Pull Request.
 
-Alternatively, consider using [fluent-plugin-forest](https://github.com/tagomoris/fluent-plugin-forest). For example, to configure multiple tags to be sent to different ElasticSearch indices:
+Alternatively, consider using [fluent-plugin-forest](https://github.com/tagomoris/fluent-plugin-forest). For example, to configure multiple tags to be sent to different Elasticsearch indices:
 
 ```
 <match my.logs.*>
@@ -489,7 +525,7 @@ And yet another option is described in Dynamic Configuration section.
 
 ### Dynamic configuration
 
-If you want configurations to depend on information in messages, you can use `elasticsearch_dynamic`. This is an experimental variation of the ElasticSearch plugin allows configuration values to be specified in ways such as the below:
+If you want configurations to depend on information in messages, you can use `elasticsearch_dynamic`. This is an experimental variation of the Elasticsearch plugin allows configuration values to be specified in ways such as the below:
 
 ```
 <match my.logs.*>

--- a/bulk.sh
+++ b/bulk.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+ES=elasticsearch.perf.lab.eng.bos.redhat.com:80
+
+echo "Delete any existing test indices"
+TESTIDX=testing-bulk-indexing
+for i in {0..2}; do curl -XDELETE $ES/$TESTIDX-$i?pretty; done
+
+# Normal bulk index, should index one record in three separate indices
+curl -XPOST $ES/_bulk --data-binary @./data-step-00.json
+curl -XPOST $ES/_bulk --data-binary @./data-step-01.json

--- a/data-step-00.json
+++ b/data-step-00.json
@@ -1,0 +1,6 @@
+{"index": { "_index" : "testing-bulk-indexing-0", "_type" : "type-00", "_id" : "0" } }
+{"field0": "0", "field1": "val-field1-00", "field2": "2017-08-10T11:40:00.000000Z" }
+{"index": { "_index" : "testing-bulk-indexing-1", "_type" : "type-00", "_id" : "0" } }
+{"field0": "0", "field1": "val-field1-00", "field2": "2017-08-10T11:40:00.000000Z" }
+{"index": { "_index" : "testing-bulk-indexing-2", "_type" : "type-00", "_id" : "0" } }
+{"field0": "0", "field1": "val-field1-00", "field2": "2017-08-10T11:40:00.000000Z" }

--- a/data-step-01.json
+++ b/data-step-01.json
@@ -1,0 +1,6 @@
+{"index": { "_index" : "testing-bulk-indexing-0", "_type" : "type-00", "_id" : "1" } }
+{"field0": "val-field0-00", "field1": "val-field1-00", "field2": "2017-08-10T11:41:00.000000Z" }
+{"index": { "_index" : "testing-bulk-indexing-1", "_type" : "type-00", "_id" : "1" } }
+{"field0": "val-field0-00", "field1": "val-field1-00", "field2": "val-field2-00" }
+{"index": { "_index" : "testing-bulk-indexing-2", "_type" : "type-00", "_id" : "1" } }
+{"field0": "val-field0-00", "field1": "val-field1-00", "field2": "2017-08-10T11:41:00.000000Z" }

--- a/fluent-plugin-elasticsearch.gemspec
+++ b/fluent-plugin-elasticsearch.gemspec
@@ -20,8 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'fluentd', '>= 0.10.43'
   s.add_runtime_dependency 'excon', '>= 0'
-  s.add_runtime_dependency 'elasticsearch'
-
+  s.add_runtime_dependency 'elasticsearch', '= 2.0.2'
 
   s.add_development_dependency 'rake', '>= 0'
   s.add_development_dependency 'webmock', '~> 1'

--- a/lib/fluent/plugin/example.bulkerror.json
+++ b/lib/fluent/plugin/example.bulkerror.json
@@ -1,0 +1,125 @@
+{
+    "took"=>3,
+    "errors"=>true,
+    "items"=>[
+        {
+            "create"=>{
+                "_index"=>".operations.2017.07.13",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV09lEt-yHUkC3cmRhe-",
+                "status"=>429,
+                "error"=>{
+                    "type"=>"es_rejected_execution_exception",
+                    "reason"=>"rejected execution of org.elasticsearch.transport.TransportService$4@1a34d37a on EsThreadPoolExecutor[bulk, queue capacity = 50, org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor@312a2162[Running, pool size = 32, active threads = 32, queued tasks = 50, completed tasks = 327053]]"
+                }
+            }
+        }
+    ]
+}
+
+{
+    "took"=>1,
+    "errors"=>true,
+    "items"=>[
+        {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-jX",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }, {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-jY",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }, {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-jZ",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }, {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-ja",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }, {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-jb",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }, {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-jc",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }, {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-jd",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }, {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-je",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }, {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-jf",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }
+    ]
+}

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -30,6 +30,7 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
   config_param :time_precision, :integer, :default => 0
   config_param :logstash_format, :bool, :default => false
   config_param :logstash_prefix, :string, :default => "logstash"
+  config_param :logstash_prefix_key, :string, :default => nil
   config_param :logstash_dateformat, :string, :default => "%Y.%m.%d"
   config_param :utc_index, :bool, :default => true
   config_param :type_name, :string, :default => "fluentd"
@@ -86,6 +87,10 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
 
     if @remove_keys_on_update && @remove_keys_on_update.is_a?(String)
       @remove_keys_on_update = @remove_keys_on_update.split ','
+    end
+
+    if @logstash_prefix_key && @logstash_prefix_key.is_a?(String)
+      @logstash_prefix_key = @logstash_prefix_key.split '.'
     end
 
     if @template_name && @template_file
@@ -304,7 +309,13 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
           record[TIMESTAMP_FIELD] = dt.iso8601(@time_precision)
         end
         dt = dt.new_offset(0) if @utc_index
-        target_index = "#{@logstash_prefix}-#{dt.strftime(@logstash_dateformat)}"
+        logstash_prefix_parent, logstash_prefix_child_key = @logstash_prefix_key ? get_parent_of(record, @logstash_prefix_key) : nil
+        if logstash_prefix_parent && logstash_prefix_parent[logstash_prefix_child_key]
+          the_logstash_prefix = logstash_prefix_parent.delete(logstash_prefix_child_key)
+        else
+          the_logstash_prefix = @logstash_prefix
+        end
+        target_index = "#{the_logstash_prefix}-#{dt.strftime(@logstash_dateformat)}"
       else
         target_index = @index_name
       end

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -1,5 +1,6 @@
 require 'helper'
 require 'date'
+require 'json'
 
 class ElasticsearchOutput < Test::Unit::TestCase
   attr_accessor :index_cmds, :index_command_counts
@@ -51,6 +52,104 @@ class ElasticsearchOutput < Test::Unit::TestCase
       index_cmds = req.body.split("\n").map {|r| JSON.parse(r) }
       @index_command_counts[url] += index_cmds.size
     end
+  end
+
+  def make_response_body(req, error_el = nil, error_status = nil, error = nil)
+    req_index_cmds = req.body.split("\n").map { |r| JSON.parse(r) }
+    items = []
+    count = 0
+    ids = 1
+    op = nil
+    index = nil
+    type = nil
+    id = nil
+    req_index_cmds.each do |cmd|
+      if count.even?
+        op = cmd.keys[0]
+        index = cmd[op]['_index']
+        type = cmd[op]['_type']
+        if cmd[op].has_key?('_id')
+          id = cmd[op]['_id']
+        else
+          id = ids
+          ids += 1
+        end
+      else
+        item = {
+          op => {
+            '_index' => index, '_type' => type, '_id' => id, '_version' => 1,
+            '_shards' => { 'total' => 1, 'successful' => 1, 'failed' => 0 },
+            'status' => op == 'create' ? 201 : 200
+          }
+        }
+        items.push(item)
+      end
+      count += 1
+    end
+    if !error_el.nil? && !error_status.nil? && !error.nil?
+      op = items[error_el].keys[0]
+      items[error_el][op].delete('_version')
+      items[error_el][op].delete('_shards')
+      items[error_el][op]['error'] = error
+      items[error_el][op]['status'] = error_status
+      errors = true
+    else
+      errors = false
+    end
+    body = { 'took' => 6, 'errors' => errors, 'items' => items }
+    return body.to_json
+  end
+
+  def stub_elastic_bad_argument(url="http://localhost:9200/_bulk")
+    error = {
+      "type" => "mapper_parsing_exception",
+      "reason" => "failed to parse [...]",
+      "caused_by" => {
+        "type" => "illegal_argument_exception",
+        "reason" => "Invalid format: \"...\""
+      }
+    }
+    stub_request(:post, url).to_return(lambda { |req| { :status => 200, :body => make_response_body(req, 1, 400, error), :headers => { 'Content-Type' => 'json' } } })
+  end
+
+  def stub_elastic_bulk_error(url="http://localhost:9200/_bulk")
+    error = {
+      "type" => "some-unrecognized-error",
+      "reason" => "some message printed here ...",
+    }
+    stub_request(:post, url).to_return(lambda { |req| { :status => 200, :body => make_response_body(req, 1, 500, error), :headers => { 'Content-Type' => 'json' } } })
+  end
+
+  def stub_elastic_bulk_rejected(url="http://localhost:9200/_bulk")
+    error = {
+      "type" => "es_rejected_execution_exception",
+      "reason" => "rejected execution of org.elasticsearch.transport.TransportService$4@1a34d37a on EsThreadPoolExecutor[bulk, queue capacity = 50, org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor@312a2162[Running, pool size = 32, active threads = 32, queued tasks = 50, completed tasks = 327053]]"
+    }
+    stub_request(:post, url).to_return(lambda { |req| { :status => 200, :body => make_response_body(req, 1, 429, error), :headers => { 'Content-Type' => 'json' } } })
+  end
+
+  def stub_elastic_out_of_memory(url="http://localhost:9200/_bulk")
+    error = {
+      "type" => "out_of_memory_error",
+      "reason" => "Java heap space"
+    }
+    stub_request(:post, url).to_return(lambda { |req| { :status => 200, :body => make_response_body(req, 1, 500, error), :headers => { 'Content-Type' => 'json' } } })
+  end
+
+  def stub_elastic_unrecognized_error(url="http://localhost:9200/_bulk")
+    error = {
+      "type" => "some-other-type",
+      "reason" => "some-other-reason"
+    }
+    stub_request(:post, url).to_return(lambda { |req| { :status => 200, :body => make_response_body(req, 1, 504, error), :headers => { 'Content-Type' => 'json' } } })
+  end
+
+  def stub_elastic_version_mismatch(url="http://localhost:9200/_bulk")
+    error = {
+      "category" => "some-other-type",
+      "reason" => "some-other-reason"
+    }
+    stub_request(:post, url).to_return(lambda { |req| { :status => 200, :body => make_response_body(req, 1, 500, error), :headers => { 'Content-Type' => 'json' } } })
   end
 
   def test_configure
@@ -818,7 +917,6 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal(index_cmds[1]['@timestamp'], ts)
   end
 
-
   def test_uses_custom_time_key_format_obscure_format
     driver.configure("logstash_format true
                       time_key_format %a %b %d %H:%M:%S %Z %Y\n")
@@ -1060,6 +1158,88 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.run
     }
     assert_equal(connection_resets, 1)
+  end
+
+  def test_bulk_bad_arguments
+    log = driver.instance.router.emit_error_handler.log
+    log.level = 'debug'
+
+    stub_elastic_ping
+    stub_elastic_bad_argument
+
+    driver.emit(sample_record)
+    driver.emit(sample_record)
+    driver.emit(sample_record)
+    driver.run
+
+    matches = log.out.logs.grep /Elasticsearch rejected document:/
+    assert_equal(1, matches.length, "Message 'Elasticsearch rejected document: ...' was not emitted")
+    matches = log.out.logs.grep /documents due to invalid field arguments/
+    assert_equal(1, matches.length, "Message 'Elasticsearch rejected # documents due to invalid field arguments ...' was not emitted")
+  end
+
+  def test_bulk_error
+    stub_elastic_ping
+    stub_elastic_bulk_error
+
+    driver.emit(sample_record)
+    driver.emit(sample_record)
+    driver.emit(sample_record)
+    assert_raise(Fluent::ElasticsearchOutput::ElasticsearchError) {
+      driver.run
+    }
+  end
+
+  def test_bulk_error_version_mismatch
+    stub_elastic_ping
+    stub_elastic_version_mismatch
+
+    driver.emit(sample_record)
+    driver.emit(sample_record)
+    driver.emit(sample_record)
+
+    assert_raise(Fluent::ElasticsearchOutput::ElasticsearchVersionMismatch) {
+      driver.run
+    }
+  end
+
+  def test_bulk_error_unrecognized_error
+    stub_elastic_ping
+    stub_elastic_unrecognized_error
+
+    driver.emit(sample_record)
+    driver.emit(sample_record)
+    driver.emit(sample_record)
+
+    assert_raise(Fluent::ElasticsearchOutput::UnrecognizedElasticsearchError) {
+      driver.run
+    }
+  end
+
+  def test_bulk_error_out_of_memory
+    stub_elastic_ping
+    stub_elastic_out_of_memory
+
+    driver.emit(sample_record)
+    driver.emit(sample_record)
+    driver.emit(sample_record)
+
+    assert_raise(Fluent::ElasticsearchOutput::ElasticsearchOutOfMemory) {
+      driver.run
+    }
+  end
+
+  def test_bulk_error_queue_full
+    stub_elastic_ping
+    stub_elastic_bulk_rejected
+
+    driver.emit(sample_record)
+    driver.emit(sample_record)
+    driver.emit(sample_record)
+
+    assert_raise(Fluent::ElasticsearchOutput::BulkIndexQueueFull) {
+      driver.run
+    }
   end
 
   def test_update_should_not_write_if_theres_no_id

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -752,7 +752,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     stub_elastic
 
     ts = "2001/02/03 13:14:01,673+02:00"
-    index = "logstash-#{Date.today.strftime("%Y.%m.%d")}"
+    index = "logstash-#{Time.now.utc.strftime("%Y.%m.%d")}"
 
     driver.emit(sample_record.merge!('@timestamp' => ts))
     driver.run


### PR DESCRIPTION
Add support for retrying on Elasticsearch errors, e.g. bulk-request-rejected and out-of-memory, and dynamic index prefix support (to eliminate need for `elasticsearch_dynamic` plugin).

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
