### PR TITLE
WIP: Retry on certain errors from Elasticsearch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,10 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in fluent-plugin-elasticsearch.gemspec
+gem 'fluentd', '~> 0.12.0'
+
 gemspec
+
 
 gem 'simplecov', require: false
 gem 'coveralls', require: false

--- a/Gemfile.v0.14
+++ b/Gemfile.v0.14
@@ -1,10 +1,7 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in fluent-plugin-elasticsearch.gemspec
-gem 'fluentd', '~> 0.12.0'
-
 gemspec
-
 
 gem 'simplecov', require: false
 gem 'coveralls', require: false

--- a/bulk.sh
+++ b/bulk.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ -z "${1:-}" ] ; then
+    echo Usage: $0 eshost:esport
+    exit 1
+fi
+
+ES=$1
+
+echo "Delete any existing test indices"
+TESTIDX=testing-bulk-indexing
+for i in {0..2}; do curl -XDELETE $ES/$TESTIDX-$i?pretty; done
+
+# Normal bulk index, should index one record in three separate indices
+curl -XPOST $ES/_bulk --data-binary @./data-step-00.json
+curl -XPOST $ES/_bulk --data-binary @./data-step-01.json

--- a/data-step-00.json
+++ b/data-step-00.json
@@ -1,0 +1,6 @@
+{"index": { "_index" : "testing-bulk-indexing-0", "_type" : "type-00", "_id" : "0" } }
+{"field0": "0", "field1": "val-field1-00", "field2": "2017-08-10T11:40:00.000000Z" }
+{"index": { "_index" : "testing-bulk-indexing-1", "_type" : "type-00", "_id" : "0" } }
+{"field0": "0", "field1": "val-field1-00", "field2": "2017-08-10T11:40:00.000000Z" }
+{"index": { "_index" : "testing-bulk-indexing-2", "_type" : "type-00", "_id" : "0" } }
+{"field0": "0", "field1": "val-field1-00", "field2": "2017-08-10T11:40:00.000000Z" }

--- a/data-step-01.json
+++ b/data-step-01.json
@@ -1,0 +1,6 @@
+{"index": { "_index" : "testing-bulk-indexing-0", "_type" : "type-00", "_id" : "1" } }
+{"field0": "val-field0-00", "field1": "val-field1-00", "field2": "2017-08-10T11:41:00.000000Z" }
+{"index": { "_index" : "testing-bulk-indexing-1", "_type" : "type-00", "_id" : "1" } }
+{"field0": "val-field0-00", "field1": "val-field1-00", "field2": "val-field2-00" }
+{"index": { "_index" : "testing-bulk-indexing-2", "_type" : "type-00", "_id" : "1" } }
+{"field0": "val-field0-00", "field1": "val-field1-00", "field2": "2017-08-10T11:41:00.000000Z" }

--- a/example.bulkerror.json
+++ b/example.bulkerror.json
@@ -1,0 +1,125 @@
+{
+    "took"=>3,
+    "errors"=>true,
+    "items"=>[
+        {
+            "create"=>{
+                "_index"=>".operations.2017.07.13",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV09lEt-yHUkC3cmRhe-",
+                "status"=>429,
+                "error"=>{
+                    "type"=>"es_rejected_execution_exception",
+                    "reason"=>"rejected execution of org.elasticsearch.transport.TransportService$4@1a34d37a on EsThreadPoolExecutor[bulk, queue capacity = 50, org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor@312a2162[Running, pool size = 32, active threads = 32, queued tasks = 50, completed tasks = 327053]]"
+                }
+            }
+        }
+    ]
+}
+
+{
+    "took"=>1,
+    "errors"=>true,
+    "items"=>[
+        {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-jX",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }, {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-jY",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }, {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-jZ",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }, {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-ja",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }, {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-jb",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }, {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-jc",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }, {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-jd",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }, {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-je",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }, {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-jf",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }
+    ]
+}

--- a/fluent-plugin-elasticsearch.gemspec
+++ b/fluent-plugin-elasticsearch.gemspec
@@ -20,8 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'fluentd', '>= 0.10.43'
   s.add_runtime_dependency 'excon', '>= 0'
-  s.add_runtime_dependency 'elasticsearch'
-
+  s.add_runtime_dependency 'elasticsearch', '>= 2.0.2'
 
   s.add_development_dependency 'rake', '>= 0'
   s.add_development_dependency 'webmock', '~> 1'

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -14,6 +14,11 @@ require_relative 'elasticsearch_index_template'
 
 class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
   class ConnectionFailure < StandardError; end
+  class BulkIndexQueueFull < StandardError; end
+  class ElasticsearchOutOfMemory < StandardError; end
+  class ElasticsearchVersionMismatch < StandardError; end
+  class UnrecognizedElasticsearchError < StandardError; end
+  class ElasticsearchError < StandardError; end
 
   Fluent::Plugin.register_output('elasticsearch', self)
 
@@ -280,8 +285,10 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
     bulk_message = ''
     header = {}
     meta = {}
-
+    records = 0
+    bulk_message_count = 0
     chunk.msgpack_each do |time, record|
+      records += 1
       next unless record.is_a? Hash
 
       if @flatten_hashes
@@ -336,9 +343,10 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
       end
 
       append_record_to_messages(@write_operation, meta, header, record, bulk_message)
+      bulk_message_count += 1
     end
 
-    send_bulk(bulk_message) unless bulk_message.empty?
+    send_bulk(bulk_message, bulk_message_count) unless bulk_message.empty?
     bulk_message.clear
   end
 
@@ -349,12 +357,95 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
     [parent_object, path[-1]]
   end
 
-  def send_bulk(data)
+  def send_bulk(data, count)
     retries = 0
     begin
       response = client.bulk body: data
       if response['errors']
-        log.error "Could not push log to Elasticsearch: #{response}"
+        errors = Hash.new(0)
+        errors_bad_resp = 0
+        errors_unrecognized = 0
+        successes = 0
+        duplicates = 0
+        bad_arguments = 0
+        # Count up the individual error types returned for each item
+        # Note: this appears to be an undocumented feature of Elasticsearch
+        # https://www.elastic.co/guide/en/elasticsearch/reference/2.4/docs-bulk.html
+        # When you submit an "index" write_operation, with no "_id" field in the
+        # metadata header, Elasticsearch will turn this into a "create"
+        # operation in the response.
+        response['items'].each do |item|
+          if item.has_key?(@write_operation)
+            write_operation = @write_operation
+          elsif INDEX_OP == @write_operation && item.has_key?(CREATE_OP)
+            write_operation = CREATE_OP
+          else
+            # When we don't have an expected ops field, something changed in the API
+            # expected return values (ES 2.x)
+            errors_bad_resp += 1
+            next
+          end
+          if item[write_operation].has_key?('status')
+            status = item[write_operation]['status']
+          else
+            # When we don't have a status field, something changed in the API
+            # expected return values (ES 2.x)
+            errors_bad_resp += 1
+            next
+          end
+          case
+          when CREATE_OP == write_operation && 409 == status
+            duplicates += 1
+          when 400 == status
+            bad_arguments += 1
+            log.debug "Elasticsearch rejected document: #{item}"
+          when [429, 500].include?(status)
+            if item[write_operation].has_key?('error') && item[write_operation]['error'].has_key?('type')
+              type = item[write_operation]['error']['type']
+            else
+              # When we don't have a type field, something changed in the API
+              # expected return values (ES 2.x)
+              errors_bad_resp += 1
+              next
+            end
+            errors[type] += 1
+          when [200, 201].include?(status)
+            successes += 1
+          else
+            errors_unrecognized += 1
+          end
+        end
+        if errors_bad_resp > 0
+          msg = "Unable to parse error response from Elasticsearch, likely an API version mismatch  #{response}"
+          log.error msg
+          raise ElasticsearchVersionMismatch, msg
+        end
+        if bad_arguments > 0
+          log.warn "Elasticsearch rejected #{bad_arguments} documents due to invalid field arguments"
+        end
+        if duplicates > 0
+          log.info "Encountered #{duplicates} duplicate(s) of #{successes} indexing chunk, ignoring"
+        end
+        msg = "Indexed (op = #{@write_operation}) #{successes} successfully, #{duplicates} duplicate(s), #{bad_arguments} bad argument(s), #{errors_unrecognized} unrecognized error(s)"
+        errors.each_key do |key|
+          msg << ", #{errors[key]} #{key} error(s)"
+        end
+        log.debug msg
+        if errors_unrecognized > 0
+          raise UnrecognizedElasticsearchError, "Unrecognized elasticsearch errors returned, retrying  #{response}"
+        end
+        errors.each_key do |key|
+          case key
+          when 'out_of_memory_error'
+            raise ElasticsearchOutOfMemory, "Elasticsearch has exhausted its heap, retrying"
+          when 'es_rejected_execution_exception'
+            raise BulkIndexQueueFull, "Bulk index queue is full, retrying"
+          else
+            raise ElasticsearchError, "Elasticsearch errors returned, retrying  #{response}"
+          end
+        end
+      else
+        log.debug "Successfully indexed (op = #{@write_operation}) #{count} documents"
       end
     rescue *client.transport.host_unreachable_exceptions => e
       if retries < 2

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -1,5 +1,6 @@
 require 'helper'
 require 'date'
+require 'json'
 
 class ElasticsearchOutput < Test::Unit::TestCase
   attr_accessor :index_cmds, :index_command_counts
@@ -51,6 +52,130 @@ class ElasticsearchOutput < Test::Unit::TestCase
       index_cmds = req.body.split("\n").map {|r| JSON.parse(r) }
       @index_command_counts[url] += index_cmds.size
     end
+  end
+
+  def make_response_body(req, error_el = nil, error_status = nil, error = nil)
+    req_index_cmds = req.body.split("\n").map { |r| JSON.parse(r) }
+    items = []
+    count = 0
+    ids = 1
+    op = nil
+    index = nil
+    type = nil
+    id = nil
+    req_index_cmds.each do |cmd|
+      if count.even?
+        op = cmd.keys[0]
+        index = cmd[op]['_index']
+        type = cmd[op]['_type']
+        if cmd[op].has_key?('_id')
+          id = cmd[op]['_id']
+        else
+          # Note: this appears to be an undocumented feature of Elasticsearch
+          # https://www.elastic.co/guide/en/elasticsearch/reference/2.4/docs-bulk.html
+          # When you submit an "index" write_operation, with no "_id" field in the
+          # metadata header, Elasticsearch will turn this into a "create"
+          # operation in the response.
+          if "index" == op
+            op = "create"
+          end
+          id = ids
+          ids += 1
+        end
+      else
+        item = {
+          op => {
+            '_index' => index, '_type' => type, '_id' => id, '_version' => 1,
+            '_shards' => { 'total' => 1, 'successful' => 1, 'failed' => 0 },
+            'status' => op == 'create' ? 201 : 200
+          }
+        }
+        items.push(item)
+      end
+      count += 1
+    end
+    if !error_el.nil? && !error_status.nil? && !error.nil?
+      op = items[error_el].keys[0]
+      items[error_el][op].delete('_version')
+      items[error_el][op].delete('_shards')
+      items[error_el][op]['error'] = error
+      items[error_el][op]['status'] = error_status
+      errors = true
+    else
+      errors = false
+    end
+    @index_cmds = items
+    body = { 'took' => 6, 'errors' => errors, 'items' => items }
+    return body.to_json
+  end
+
+  def stub_elastic_bad_argument(url="http://localhost:9200/_bulk")
+    error = {
+      "type" => "mapper_parsing_exception",
+      "reason" => "failed to parse [...]",
+      "caused_by" => {
+        "type" => "illegal_argument_exception",
+        "reason" => "Invalid format: \"...\""
+      }
+    }
+    stub_request(:post, url).to_return(lambda { |req| { :status => 200, :body => make_response_body(req, 1, 400, error), :headers => { 'Content-Type' => 'json' } } })
+  end
+
+  def stub_elastic_bulk_error(url="http://localhost:9200/_bulk")
+    error = {
+      "type" => "some-unrecognized-error",
+      "reason" => "some message printed here ...",
+    }
+    stub_request(:post, url).to_return(lambda { |req| { :status => 200, :body => make_response_body(req, 1, 500, error), :headers => { 'Content-Type' => 'json' } } })
+  end
+
+  def stub_elastic_bulk_rejected(url="http://localhost:9200/_bulk")
+    error = {
+      "type" => "es_rejected_execution_exception",
+      "reason" => "rejected execution of org.elasticsearch.transport.TransportService$4@1a34d37a on EsThreadPoolExecutor[bulk, queue capacity = 50, org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor@312a2162[Running, pool size = 32, active threads = 32, queued tasks = 50, completed tasks = 327053]]"
+    }
+    stub_request(:post, url).to_return(lambda { |req| { :status => 200, :body => make_response_body(req, 1, 429, error), :headers => { 'Content-Type' => 'json' } } })
+  end
+
+  def stub_elastic_out_of_memory(url="http://localhost:9200/_bulk")
+    error = {
+      "type" => "out_of_memory_error",
+      "reason" => "Java heap space"
+    }
+    stub_request(:post, url).to_return(lambda { |req| { :status => 200, :body => make_response_body(req, 1, 500, error), :headers => { 'Content-Type' => 'json' } } })
+  end
+
+  def stub_elastic_unrecognized_error(url="http://localhost:9200/_bulk")
+    error = {
+      "type" => "some-other-type",
+      "reason" => "some-other-reason"
+    }
+    stub_request(:post, url).to_return(lambda { |req| { :status => 200, :body => make_response_body(req, 1, 504, error), :headers => { 'Content-Type' => 'json' } } })
+  end
+
+  def stub_elastic_version_mismatch(url="http://localhost:9200/_bulk")
+    error = {
+      "category" => "some-other-type",
+      "reason" => "some-other-reason"
+    }
+    stub_request(:post, url).to_return(lambda { |req| { :status => 200, :body => make_response_body(req, 1, 500, error), :headers => { 'Content-Type' => 'json' } } })
+  end
+
+  def stub_elastic_index_to_create(url="http://localhost:9200/_bulk")
+    error = {
+      "category" => "some-other-type",
+      "reason" => "some-other-reason",
+      "type" => "some-other-type"
+    }
+    stub_request(:post, url).to_return(lambda { |req| { :status => 200, :body => make_response_body(req, 0, 500, error), :headers => { 'Content-Type' => 'json' } } })
+  end
+
+  def stub_elastic_unexpected_response_op(url="http://localhost:9200/_bulk")
+    error = {
+      "category" => "some-other-type",
+      "reason" => "some-other-reason"
+    }
+    stub_request(:post, url).to_return(lambda { |req| bodystr = make_response_body(req, 0, 500, error); body = JSON.parse(bodystr); body['items'][0]['unknown'] = body['items'][0].delete('create'); { :status => 200, :body => body.to_json, :headers => { 'Content-Type' => 'json' } } })
   end
 
   def test_configure
@@ -766,7 +891,6 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal(index_cmds[1]['@timestamp'], ts)
   end
 
-
   def test_uses_custom_time_key_format_obscure_format
     driver.configure("logstash_format true
                       time_key_format %a %b %d %H:%M:%S %Z %Y\n")
@@ -1008,6 +1132,111 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.run
     }
     assert_equal(connection_resets, 1)
+  end
+
+  def test_bulk_bad_arguments
+    log = driver.instance.router.emit_error_handler.log
+    log.level = 'debug'
+
+    stub_elastic_ping
+    stub_elastic_bad_argument
+
+    driver.emit(sample_record)
+    driver.emit(sample_record)
+    driver.emit(sample_record)
+    driver.run
+
+    matches = log.out.logs.grep /Elasticsearch rejected document:/
+    assert_equal(1, matches.length, "Message 'Elasticsearch rejected document: ...' was not emitted")
+    matches = log.out.logs.grep /documents due to invalid field arguments/
+    assert_equal(1, matches.length, "Message 'Elasticsearch rejected # documents due to invalid field arguments ...' was not emitted")
+  end
+
+  def test_bulk_error
+    stub_elastic_ping
+    stub_elastic_bulk_error
+
+    driver.emit(sample_record)
+    driver.emit(sample_record)
+    driver.emit(sample_record)
+    assert_raise(Fluent::ElasticsearchOutput::ElasticsearchError) {
+      driver.run
+    }
+  end
+
+  def test_bulk_error_version_mismatch
+    stub_elastic_ping
+    stub_elastic_version_mismatch
+
+    driver.emit(sample_record)
+    driver.emit(sample_record)
+    driver.emit(sample_record)
+
+    assert_raise(Fluent::ElasticsearchOutput::ElasticsearchVersionMismatch) {
+      driver.run
+    }
+  end
+
+  def test_bulk_error_unrecognized_error
+    stub_elastic_ping
+    stub_elastic_unrecognized_error
+
+    driver.emit(sample_record)
+    driver.emit(sample_record)
+    driver.emit(sample_record)
+
+    assert_raise(Fluent::ElasticsearchOutput::UnrecognizedElasticsearchError) {
+      driver.run
+    }
+  end
+
+  def test_bulk_error_out_of_memory
+    stub_elastic_ping
+    stub_elastic_out_of_memory
+
+    driver.emit(sample_record)
+    driver.emit(sample_record)
+    driver.emit(sample_record)
+
+    assert_raise(Fluent::ElasticsearchOutput::ElasticsearchOutOfMemory) {
+      driver.run
+    }
+  end
+
+  def test_bulk_error_queue_full
+    stub_elastic_ping
+    stub_elastic_bulk_rejected
+
+    driver.emit(sample_record)
+    driver.emit(sample_record)
+    driver.emit(sample_record)
+
+    assert_raise(Fluent::ElasticsearchOutput::BulkIndexQueueFull) {
+      driver.run
+    }
+  end
+
+  def test_bulk_index_into_a_create
+    stub_elastic_ping
+    stub_elastic_index_to_create
+
+    driver.emit(sample_record)
+
+    assert_raise(Fluent::ElasticsearchOutput::ElasticsearchError) {
+      driver.run
+    }
+    assert(index_cmds[0].has_key?("create"))
+  end
+
+  def test_bulk_unexpected_response_op
+    stub_elastic_ping
+    stub_elastic_unexpected_response_op
+
+    driver.emit(sample_record)
+
+    assert_raise(Fluent::ElasticsearchOutput::ElasticsearchVersionMismatch) {
+      driver.run
+    }
   end
 
   def test_update_should_not_write_if_theres_no_id


### PR DESCRIPTION
Work-In-Progress: more work is needed to verify the emitted logs
are as expected.

There are five cases for an exception is raised to cause the output
buffer thread to retry an operation:

  1. ElasticsearchVersionMismatch - We did not receive an error
     payload that matches our expectations, so this is considered
     a possible Elasticsearch version mismatch
  2. UnrecognizedElasticsearchError - We encountered some error
     from Elasticsearch which we don't recognize
  3. ElasticsearchOutOfMemory - If Elasticsearch is responding, but
     telling us it is out of memory, status code 500, with an error
     type of "out_of_memory_error", we'll keep retrying until it
     returns to us successfully
  4. BulkIndexQueueFull - If Elasticsearch responds with a bulk
     index request rejected error, 429, with an error type of
     "es_rejected_execution_exception", we'll keep retrying until
     it returns to us successfully
  5. ElasticsearchError - Some other status code 500 with an
     unknown error type.

We also now:

  * log at debug level all documents rejected because of bad arguments
  * log at warn level a summary of the number of documents with bad
    arguments
  * log at info level a summary of the number of duplicate documents
    (if the write_operation is "create")
  * log at debug level a summary of all the documents successfully
    indexed

Note we only perform these changes currently for the "static" version of
the plugin.

This commit also fixes the dependencies for Elasticsearch 2.x and
Fluentd v0.12.

DESCRIPTION HERE

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
